### PR TITLE
Create deploy_documentation.yml

### DIFF
--- a/.github/workflows/deploy_documentation.yml
+++ b/.github/workflows/deploy_documentation.yml
@@ -1,0 +1,49 @@
+name: Deploy DocC to GitHub Pages
+
+on:
+  # trigger this workflow whenever "main" branch has been pushed
+  push:
+    branches: [ "main" ]
+
+# Set up GITHUB_TOKEN permission for the deployment
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+# Allow workflow concurrency
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      # Mandatory settings for GitHub Pages deployment
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: macos-13  # to use the latest version that is available on  GitHub Actions
+    steps:
+    - name: Checkout 🛎️
+      uses: actions/checkout@v3
+    - name: Setup Xcode version
+      uses: maxim-lobanov/setup-xcode@v1 # To set up xcode version
+      with:
+        xcode-version: '15.0'
+    - name: Build DocC
+      run: | # If you use docc-plugin, you might be able to use docc-plugin command instead
+        xcodebuild docbuild -scheme Grape \
+          -derivedDataPath /tmp/docbuild \
+          -destination 'generic/platform=iOS';
+        $(xcrun --find docc) process-archive \
+          transform-for-static-hosting /tmp/docbuild/Build/Products/Debug-iphoneos/Grape.doccarchive \
+          --hosting-base-path grape \
+          --output-path docs;
+        echo "<script>window.location.href += \"/documentation/grape\"</script>" > docs/index.html
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v1
+      with:
+        # Upload docs folder
+        path: 'docs'
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v1


### PR DESCRIPTION
This PR includes a new GitHub Actions workflow.

The workflow builds DocC documentations for the target, "Grape".

To use this workflow you should modify the GitHub Pages Settings:

1. Go to Settings > Pages > Build and deployment 
2. Set `Source` to `GitHub Actions`
3. Go to Actions > General > Workflow permissions
4. Enable "Read and write permissions"

Then, it will work on "main" branch when there's any push on the branch