### PR TITLE
Doc edits

### DIFF
--- a/Sources/ForceSimulation/ForceLike.swift
+++ b/Sources/ForceSimulation/ForceLike.swift
@@ -7,6 +7,7 @@
 
 
 /// A protocol that represents a force.
+/// 
 /// A force takes a simulation state and modifies its node positions and velocities.
 public protocol ForceLike {
 

--- a/Sources/ForceSimulation/ForceSimulation.docc/Creating2DAnd3DSimulations.md
+++ b/Sources/ForceSimulation/ForceSimulation.docc/Creating2DAnd3DSimulations.md
@@ -3,7 +3,8 @@
 
 ## Overview
 
-You can simply create 2D or 3D simulations by using Simulation2D or Simulation3D:
+Create 2D or 3D simulations by using Simulation2D or Simulation3D.
+For example, the following code creates a 2D force simulation.
 
 ```swift
 
@@ -30,4 +31,4 @@ for i in 0..<120 {
 
 ```
 
-See [Example](https://github.com/li3zhen1/Grape/tree/main/Examples/ForceDirectedGraphExample) for more details.
+See [Examples](https://github.com/li3zhen1/Grape/tree/main/Examples) for example Xcode projects.

--- a/Sources/ForceSimulation/ForceSimulation.docc/Documentation.md
+++ b/Sources/ForceSimulation/ForceSimulation.docc/Documentation.md
@@ -1,10 +1,12 @@
 # ``ForceSimulation``
 
-Run force simulation on any dimensions.
+Run force simulation within any number of dimensions.
 
 ## Overview
 
-`ForceSimulation` is a force simulation library that enables you to create any dimensional simulation with velocity Verlet integration. The basic concepts of simulations and forces can be found here: [Force simulations - D3](https://d3js.org/d3-force/simulation). 
+The `ForceSimulation` library enables you to create any dimensional simulation that uses velocity Verlet integration.
+
+For more information on force simulations, read: [Force simulations - D3](https://d3js.org/d3-force/simulation). 
 
 
 @Image(source: "ForceDirectedGraph.png", alt: "An example of 2D force directied graph.")
@@ -20,25 +22,31 @@ Run force simulation on any dimensions.
 * ``Simulation3D``
 * ``SimulationKD``
 
-### Creating forces in a simulation
+### Spatial data structures
 
-* ``Simulation2D/CenterForce``
-* ``Simulation2D/CollideForce``
-* ``Simulation2D/LinkForce``
-* ``Simulation2D/ManyBodyForce``
-* ``Simulation2D/DirectionForce2D``
-* ``Simulation2D/RadialForce``
+- ``Quadtree``
+- ``QuadtreeDelegate``
+- ``QuadBox``
+- ``Octree``
+- ``OctreeDelegate``
+- ``OctBox``
+- ``NDTree``
+- ``NDTreeDelegate``
+- ``NDBox``
+- ``EdgeID``
 
-* ``Simulation3D/CenterForce``
-* ``Simulation3D/CollideForce``
-* ``Simulation3D/LinkForce``
-* ``Simulation3D/ManyBodyForce``
-* ``Simulation3D/DirectionForce3D``
-* ``Simulation3D/RadialForce``
+### Deterministic Randomness
 
-* ``SimulationKD/CenterForce``
-* ``SimulationKD/CollideForce``
-* ``SimulationKD/LinkForce``
-* ``SimulationKD/ManyBodyForce``
-* ``SimulationKD/DirectionForce``
-* ``SimulationKD/RadialForce``
+- ``FloatLinearCongruentialGenerator``
+- ``LinearCongruentialGenerator``
+
+### Supporting Protocols
+
+- ``ForceLike``
+- ``NDTreeBasedForceLike``
+- ``VectorLike``
+- ``SimulatableFloatingPoint``
+
+### Error Types
+
+- ``ManyBodyForce2DError``

--- a/Sources/ForceSimulation/ForceSimulation.docc/Simulation2D.md
+++ b/Sources/ForceSimulation/ForceSimulation.docc/Simulation2D.md
@@ -1,0 +1,48 @@
+# ``ForceSimulation/Simulation2D``
+
+A force-simulation for distributed layout within a two-dimensional space.
+
+## Topics
+
+### Creating a 2D force simulation
+
+- ``init(nodeIds:alpha:alphaMin:alphaDecay:alphaTarget:velocityDecay:setInitialStatus:)``
+
+### Creating forces for the simulation
+
+- ``createCenterForce(center:strength:)``
+- ``CenterForce``
+- ``createCollideForce(radius:strength:iterationsPerTick:)``
+- ``CollideForce``
+- ``createLinkForce(_:stiffness:originalLength:iterationsPerTick:)-652gu``
+- ``createLinkForce(_:stiffness:originalLength:iterationsPerTick:)-9iwy5``
+- ``LinkForce``
+- ``createManyBodyForce(strength:nodeMass:)``
+- ``ManyBodyForce``
+- ``createPositionForce(direction:targetOnDirection:strength:)``
+- ``DirectionForce2D``
+- ``createRadialForce(center:radius:strength:)``
+- ``RadialForce``
+
+### Running the simulation
+
+- ``tick(iterationCount:)``
+- ``resetAlpha(_:)``
+
+### Inspecting the simulation
+
+- ``alpha``
+- ``alphaMin``
+- ``alphaDecay``
+- ``alphaTarget``
+- ``initializedAlpha``
+- ``velocityDecay``
+- ``forces``
+
+### Inspecting nodes within the simulation
+
+- ``nodeIds``
+- ``nodeFixations``
+- ``nodePositions``
+- ``nodeVelocities``
+- ``getIndex(of:)``

--- a/Sources/ForceSimulation/ForceSimulation.docc/Simulation3D.md
+++ b/Sources/ForceSimulation/ForceSimulation.docc/Simulation3D.md
@@ -1,0 +1,48 @@
+# ``ForceSimulation/Simulation3D``
+
+A force-simulation for distributed layout within a three-dimensional space.
+
+## Topics
+
+### Creating a 3D force simulation
+
+- ``init(nodeIds:alpha:alphaMin:alphaDecay:alphaTarget:velocityDecay:setInitialStatus:)``
+
+### Creating forces for the simulation
+
+- ``createCenterForce(center:strength:)``
+- ``CenterForce``
+- ``createCollideForce(radius:strength:iterationsPerTick:)``
+- ``CollideForce``
+- ``createLinkForce(_:stiffness:originalLength:iterationsPerTick:)-2bixz``
+- ``createLinkForce(_:stiffness:originalLength:iterationsPerTick:)-3sa2n``
+- ``LinkForce``
+- ``createManyBodyForce(strength:nodeMass:)``
+- ``ManyBodyForce``
+- ``createPositionForce(direction:targetOnDirection:strength:)``
+- ``DirectionForce3D``
+- ``createRadialForce(center:radius:strength:)``
+- ``RadialForce``
+
+### Running the simulation
+
+- ``tick(iterationCount:)``
+- ``resetAlpha(_:)``
+
+### Inspecting the simulation
+
+- ``alpha``
+- ``alphaMin``
+- ``alphaDecay``
+- ``alphaTarget``
+- ``initializedAlpha``
+- ``velocityDecay``
+- ``forces``
+
+### Inspecting nodes within the simulation
+
+- ``nodeIds``
+- ``nodeFixations``
+- ``nodePositions``
+- ``nodeVelocities``
+- ``getIndex(of:)``

--- a/Sources/ForceSimulation/ForceSimulation.docc/SimulationKD.md
+++ b/Sources/ForceSimulation/ForceSimulation.docc/SimulationKD.md
@@ -1,0 +1,48 @@
+# ``ForceSimulation/SimulationKD``
+
+A force-simulation for distributed layout within a multi-dimensional space.
+
+## Topics
+
+### Creating a multi-dimensional force simulation
+
+- ``init(nodeIds:alpha:alphaMin:alphaDecay:alphaTarget:velocityDecay:setInitialStatus:)``
+
+### Creating forces for the simulation
+
+- ``createCenterForce(center:strength:)``
+- ``CenterForce``
+- ``createCollideForce(radius:strength:iterationsPerTick:)``
+- ``CollideForce``
+- ``createLinkForce(_:stiffness:originalLength:iterationsPerTick:)-46ea4``
+- ``createLinkForce(_:stiffness:originalLength:iterationsPerTick:)-9opzo``
+- ``LinkForce``
+- ``createManyBodyForce(strength:nodeMass:)``
+- ``ManyBodyForce``
+- ``createPositionForce(direction:targetOnDirection:strength:)``
+- ``DirectionForce``
+- ``createRadialForce(center:radius:strength:)``
+- ``RadialForce``
+
+### Running the simulation
+
+- ``tick(iterationCount:)``
+- ``resetAlpha(_:)``
+
+### Inspecting the simulation
+
+- ``alpha``
+- ``alphaMin``
+- ``alphaDecay``
+- ``alphaTarget``
+- ``initializedAlpha``
+- ``velocityDecay``
+- ``forces``
+
+### Inspecting nodes within the simulation
+
+- ``nodeIds``
+- ``nodeFixations``
+- ``nodePositions``
+- ``nodeVelocities``
+- ``getIndex(of:)``

--- a/Sources/ForceSimulation/NDTree/NDBox.swift
+++ b/Sources/ForceSimulation/NDTree/NDBox.swift
@@ -6,6 +6,7 @@
 //
 
 /// A box in N-dimensional space.
+///
 /// - Note: `p0` is the minimum point of the box, `p1` is the maximum point of the box.
 public struct NDBox<V> where V: VectorLike {
     /// the minimum anchor of the box
@@ -15,6 +16,7 @@ public struct NDBox<V> where V: VectorLike {
     public var p1: V
 
     /// Create a box with 2 anchors.
+    ///
     /// - Parameters:
     ///   - p0: anchor
     ///   - p1: another anchor in the diagonal position of `p0`
@@ -39,6 +41,7 @@ public struct NDBox<V> where V: VectorLike {
     }
 
     /// Create a box with 2 anchors.
+    ///
     /// - Parameters:
     ///   - pMin: minimum anchor of the box
     ///   - pMax: maximum anchor of the box
@@ -111,6 +114,7 @@ extension NDBox {
 extension NDBox {
 
     /// Get the small box that contains a list points and guarantees the box's size is at least 1x..x1.
+    ///
     /// - Parameter points: The points to be covered.
     /// - Returns: The box that contains all the points.
     @inlinable public static func cover(of points: [V]) -> Self {
@@ -141,6 +145,7 @@ extension NDBox {
     }
 
     /// Get the small box that contains a list points and guarantees the box's size is at least 1x..x1.
+    /// 
     /// Please note that KeyPath is slow.
     ///
     /// - Parameter

--- a/Sources/ForceSimulation/NDTree/NDTree.swift
+++ b/Sources/ForceSimulation/NDTree/NDTree.swift
@@ -5,7 +5,8 @@
 //  Created by li3zhen1 on 10/14/23.
 //
 
-/// The data structure carried by a node of NDTree
+/// The data structure carried by a node of NDTree.
+///
 /// It receives notifications when a node is added or removed on a node, regardless of whether the node is internal or leaf.
 /// It is designed to calculate properties like a box's center of mass.
 public protocol NDTreeDelegate {
@@ -13,7 +14,8 @@ public protocol NDTreeDelegate {
     associatedtype V: VectorLike
 
     /// Called when a node is added on a node, regardless of whether the node is internal or leaf.
-    /// If you add `n` points to the root, this method will be called `n` times in the root delegate, 
+    ///
+    /// If you add `n` points to the root, this method will be called `n` times in the root delegate,
     /// although it is probably not containing points now.
     /// - Parameters:
     ///   - node: The nodeID of the node that is added.
@@ -23,11 +25,13 @@ public protocol NDTreeDelegate {
     /// Called when a node is removed on a node, regardless of whether the node is internal or leaf.
     mutating func didRemoveNode(_ node: NodeID, at position: V)
 
-    /// Copy object. This method is called when the root box is not large enough to cover the new nodes.
-    /// The method
+    /// Copy object. 
+    ///
+    /// This method is called when the root box is not large enough to cover the new nodes.
     func copy() -> Self
 
     /// Create new object with properties set to initial value as if the box is empty.
+    ///
     /// However, you can still carry something like a closure to get information from outside.
     /// This method is called when a leaf box is splited due to the insertion of a new node in this box.
     func spawn() -> Self
@@ -155,6 +159,7 @@ public final class NDTree<V, D> where V: VectorLike, D: NDTreeDelegate, D.V == V
     }
 
     /// Expand the current node multiple times by calling `expand(towards:)`, until the point is covered.
+    ///
     /// - Parameter point: The point to be covered.
     private func cover(_ point: V) {
         if box.contains(point) { return }
@@ -165,8 +170,9 @@ public final class NDTree<V, D> where V: VectorLike, D: NDTreeDelegate, D.V == V
         } while !box.contains(point)
     }
 
-    /// Expand the current node towards a direction. The expansion
-    /// will double the size on each dimension. Then the data in delegate will be copied to the new children.
+    /// Expand the current node towards a direction. 
+    ///
+    /// The expansion will double the size on each dimension. Then the data in delegate will be copied to the new children.
     /// - Parameter direction: An Integer between 0 and `directionCount - 1`, where `directionCount` equals to 2^(dimension of the vector).
     private func expand(towards direction: Direction) {
         let nailedDirection = (Self.directionCount - 1) - direction
@@ -195,6 +201,7 @@ public final class NDTree<V, D> where V: VectorLike, D: NDTreeDelegate, D.V == V
     }
 
     /// The children count of a node in NDTree.
+    ///
     /// Should be equal to the 2^(dimension of the vector).
     /// For example, a 2D vector should have 4 children, a 3D vector should have 8 children.
     /// This property is a getter property but it is probably be inlined.
@@ -232,6 +239,7 @@ public final class NDTree<V, D> where V: VectorLike, D: NDTreeDelegate, D.V == V
     }
 
     /// Copy object while holding the same reference to children.
+    ///
     /// Consider this function something you would do when working with linked list.
     private func shallowCopy() -> NDTree<V, D> {
         let copy = NDTree(
@@ -246,6 +254,7 @@ public final class NDTree<V, D> where V: VectorLike, D: NDTreeDelegate, D.V == V
     }
 
     /// Get the index of the child that contains the point.
+    ///
     /// **Complexity**: `O(n*(2^n))`, where `n` is the dimension of the vector.
     private func getIndexInChildren(_ point: V, relativeTo originalPoint: V) -> Int {
         var index = 0
@@ -262,7 +271,8 @@ public final class NDTree<V, D> where V: VectorLike, D: NDTreeDelegate, D.V == V
 extension NDTree where D.NodeID == Int {
 
     /// Initialize a NDTree with a list of points and a key path to the vector.
-    /// - Parameters: 
+    ///
+    /// - Parameters:
     ///  - points: A list of points. The points are only used to calculate the covering box. You should still call `add` to add the points to the tree.
     ///  - clusterDistance: If 2 points are close enough, they will be clustered into the same leaf node.
     ///  - buildRootDelegate: A closure that tells the tree how to initialize the data you want to store in the root.
@@ -282,7 +292,8 @@ extension NDTree where D.NodeID == Int {
     }
 
     /// Initialize a NDTree with a list of points and a key path to the vector.
-    /// - Parameters: 
+    ///
+    /// - Parameters:
     ///  - points: A list of points. The points are only used to calculate the covering box. You should still call `add` to add the points to the tree.
     ///  - keyPath: A key path to the vector in the element of the list.
     ///  - clusterDistance: If 2 points are close enough, they will be clustered into the same leaf node.
@@ -309,10 +320,14 @@ extension NDTree {
     /// The bounding box of the current node
     @inlinable public var extent: Box { box }
 
-    /// Returns true is the current tree node is leaf. Does not guarantee that the tree node has point in it.
+    /// Returns true is the current tree node is leaf. 
+    ///
+    /// Does not guarantee that the tree node has point in it.
     @inlinable public var isLeaf: Bool { children == nil }
 
-    /// Returns true is the current tree node is internal. Internal tree node are always empty and do not contain any points.
+    /// Returns true is the current tree node is internal. 
+    ///
+    /// Internal tree node are always empty and do not contain any points.
     @inlinable public var isInternalNode: Bool { children != nil }
 
     /// Returns true is the current tree node is leaf and has point in it.
@@ -323,6 +338,7 @@ extension NDTree {
 
 
     /// Visit the tree in pre-order.
+    /// 
     /// - Parameter shouldVisitChildren: a closure that returns a boolean value indicating whether should continue to visit children.
     @inlinable public func visit(shouldVisitChildren: (NDTree<V,D>) -> Bool) {
         if shouldVisitChildren(self), let children {
@@ -334,6 +350,7 @@ extension NDTree {
     }
     
     /// Visit the tree in post-order.
+    ///
     /// - Parameter action: a closure that takes a tree as its argument.
     @inlinable public func visitPostOrdered(
         _ action: (NDTree<V, D>) -> ()

--- a/Sources/ForceSimulation/NDTree/Octree.swift
+++ b/Sources/ForceSimulation/NDTree/Octree.swift
@@ -8,7 +8,8 @@
 #if canImport(simd)
 import simd
 
-/// The data structure carried by a node of NDTree
+/// The data structure carried by a node of NDTree.
+///
 /// It receives notifications when a node is added or removed on a node, regardless of whether the node is internal or leaf.
 /// It is designed to calculate properties like a box's center of mass.
 public protocol OctreeDelegate {
@@ -16,7 +17,8 @@ public protocol OctreeDelegate {
     typealias V = simd_float3
 
     /// Called when a node is added on a node, regardless of whether the node is internal or leaf.
-    /// If you add `n` points to the root, this method will be called `n` times in the root delegate, 
+    ///
+    /// If you add `n` points to the root, this method will be called `n` times in the root delegate,
     /// although it is probably not containing points now.
     /// - Parameters:
     ///   - node: The nodeID of the node that is added.
@@ -26,17 +28,20 @@ public protocol OctreeDelegate {
     /// Called when a node is removed on a node, regardless of whether the node is internal or leaf.
     mutating func didRemoveNode(_ node: NodeID, at position: V)
 
-    /// Copy object. This method is called when the root box is not large enough to cover the new nodes.
-    /// The method
+    /// Copy object. 
+    ///
+    /// This method is called when the root box is not large enough to cover the new nodes.
     func copy() -> Self
 
     /// Create new object with properties set to initial value as if the box is empty.
+    ///
     /// However, you can still carry something like a closure to get information from outside.
     /// This method is called when a leaf box is splited due to the insertion of a new node in this box.
     func spawn() -> Self
 }
 
-/// A node in NDTree
+/// A node in NDTree.
+///
 /// - Note: `NDTree` is a generic type that can be used in any dimension.
 ///        `NDTree` is a reference type.
 public final class Octree<D> where D: OctreeDelegate {
@@ -170,8 +175,9 @@ public final class Octree<D> where D: OctreeDelegate {
         } while !box.contains(point)
     }
 
-    /// Expand the current node towards a direction. The expansion
-    /// will double the size on each dimension. Then the data in delegate will be copied to the new children.
+    /// Expand the current node towards a direction. 
+    ///
+    /// The expansion will double the size on each dimension. Then the data in delegate will be copied to the new children.
     /// - Parameter direction: An Integer between 0 and `directionCount - 1`, where `directionCount` equals to 2^(dimension of the vector).
     private func expand(towards direction: Direction) {
         let nailedDirection = (Self.directionCount - 1) - direction
@@ -200,6 +206,7 @@ public final class Octree<D> where D: OctreeDelegate {
     }
 
     /// The children count of a node in NDTree.
+    ///
     /// Should be equal to the 2^(dimension of the vector).
     /// For example, a 2D vector should have 4 children, a 3D vector should have 8 children.
     /// This property is a getter property but it is probably be inlined.
@@ -237,6 +244,7 @@ public final class Octree<D> where D: OctreeDelegate {
     }
 
     /// Copy object while holding the same reference to children.
+    ///
     /// Consider this function something you would do when working with linked list.
     private func shallowCopy() -> Self {
         let copy = Self(
@@ -251,6 +259,7 @@ public final class Octree<D> where D: OctreeDelegate {
     }
 
     /// Get the index of the child that contains the point.
+    ///
     /// **Complexity**: `O(n*(2^n))`, where `n` is the dimension of the vector.
     private func getIndexInChildren(_ point: V, relativeTo originalPoint: V) -> Int {
         // var index = 0
@@ -271,7 +280,8 @@ public final class Octree<D> where D: OctreeDelegate {
 extension Octree where D.NodeID == Int {
 
     /// Initialize a NDTree with a list of points and a key path to the vector.
-    /// - Parameters: 
+    ///
+    /// - Parameters:
     ///  - points: A list of points. The points are only used to calculate the covering box. You should still call `add` to add the points to the tree.
     ///  - clusterDistance: If 2 points are close enough, they will be clustered into the same leaf node.
     ///  - buildRootDelegate: A closure that tells the tree how to initialize the data you want to store in the root.
@@ -291,7 +301,8 @@ extension Octree where D.NodeID == Int {
     }
 
     /// Initialize a NDTree with a list of points and a key path to the vector.
-    /// - Parameters: 
+    ///
+    /// - Parameters:
     ///  - points: A list of points. The points are only used to calculate the covering box. You should still call `add` to add the points to the tree.
     ///  - keyPath: A key path to the vector in the element of the list.
     ///  - clusterDistance: If 2 points are close enough, they will be clustered into the same leaf node.
@@ -318,10 +329,14 @@ extension Octree {
     /// The bounding box of the current node
     @inlinable public var extent: Box { box }
 
-    /// Returns true is the current tree node is leaf. Does not guarantee that the tree node has point in it.
+    /// Returns true is the current tree node is leaf. 
+    ///
+    /// Does not guarantee that the tree node has point in it.
     @inlinable public var isLeaf: Bool { children == nil }
 
-    /// Returns true is the current tree node is internal. Internal tree node are always empty and do not contain any points.
+    /// Returns true is the current tree node is internal. 
+    ///
+    /// Internal tree node are always empty and do not contain any points.
     @inlinable public var isInternalNode: Bool { children != nil }
 
     /// Returns true is the current tree node is leaf and has point in it.

--- a/Sources/ForceSimulation/NDTree/Quadtree.swift
+++ b/Sources/ForceSimulation/NDTree/Quadtree.swift
@@ -8,7 +8,8 @@
 #if canImport(simd)
 import simd
 
-/// The data structure carried by a node of NDTree
+/// The data structure carried by a node of NDTree.
+///
 /// It receives notifications when a node is added or removed on a node, regardless of whether the node is internal or leaf.
 /// It is designed to calculate properties like a box's center of mass.
 public protocol QuadtreeDelegate {
@@ -16,7 +17,8 @@ public protocol QuadtreeDelegate {
     typealias V = simd_double2
 
     /// Called when a node is added on a node, regardless of whether the node is internal or leaf.
-    /// If you add `n` points to the root, this method will be called `n` times in the root delegate, 
+    ///
+    /// If you add `n` points to the root, this method will be called `n` times in the root delegate,
     /// although it is probably not containing points now.
     /// - Parameters:
     ///   - node: The nodeID of the node that is added.
@@ -26,17 +28,20 @@ public protocol QuadtreeDelegate {
     /// Called when a node is removed on a node, regardless of whether the node is internal or leaf.
     mutating func didRemoveNode(_ node: NodeID, at position: V)
 
-    /// Copy object. This method is called when the root box is not large enough to cover the new nodes.
-    /// The method
+    /// Copy object. 
+    ///
+    /// This method is called when the root box is not large enough to cover the new nodes.
     func copy() -> Self
 
     /// Create new object with properties set to initial value as if the box is empty.
+    ///
     /// However, you can still carry something like a closure to get information from outside.
     /// This method is called when a leaf box is splited due to the insertion of a new node in this box.
     func spawn() -> Self
 }
 
 /// A node in NDTree
+///
 /// - Note: `NDTree` is a generic type that can be used in any dimension.
 ///        `NDTree` is a reference type.
 public final class Quadtree<D> where D: QuadtreeDelegate {
@@ -170,8 +175,9 @@ public final class Quadtree<D> where D: QuadtreeDelegate {
         } while !box.contains(point)
     }
 
-    /// Expand the current node towards a direction. The expansion
-    /// will double the size on each dimension. Then the data in delegate will be copied to the new children.
+    /// Expand the current node towards a direction. 
+    ///
+    /// The expansion will double the size on each dimension. Then the data in delegate will be copied to the new children.
     /// - Parameter direction: An Integer between 0 and `directionCount - 1`, where `directionCount` equals to 2^(dimension of the vector).
     private func expand(towards direction: Direction) {
         let nailedDirection = (Self.directionCount - 1) - direction
@@ -200,6 +206,7 @@ public final class Quadtree<D> where D: QuadtreeDelegate {
     }
 
     /// The children count of a node in NDTree.
+    ///
     /// Should be equal to the 2^(dimension of the vector).
     /// For example, a 2D vector should have 4 children, a 3D vector should have 8 children.
     /// This property is a getter property but it is probably be inlined.
@@ -237,6 +244,7 @@ public final class Quadtree<D> where D: QuadtreeDelegate {
     }
 
     /// Copy object while holding the same reference to children.
+    ///
     /// Consider this function something you would do when working with linked list.
     private func shallowCopy() -> Self {
         let copy = Self(
@@ -251,6 +259,7 @@ public final class Quadtree<D> where D: QuadtreeDelegate {
     }
 
     /// Get the index of the child that contains the point.
+    ///
     /// **Complexity**: `O(n*(2^n))`, where `n` is the dimension of the vector.
     private func getIndexInChildren(_ point: V, relativeTo originalPoint: V) -> Int {
         // var index = 0
@@ -271,7 +280,8 @@ public final class Quadtree<D> where D: QuadtreeDelegate {
 extension Quadtree where D.NodeID == Int {
 
     /// Initialize a NDTree with a list of points and a key path to the vector.
-    /// - Parameters: 
+    ///
+    /// - Parameters:
     ///  - points: A list of points. The points are only used to calculate the covering box. You should still call `add` to add the points to the tree.
     ///  - clusterDistance: If 2 points are close enough, they will be clustered into the same leaf node.
     ///  - buildRootDelegate: A closure that tells the tree how to initialize the data you want to store in the root.
@@ -291,7 +301,8 @@ extension Quadtree where D.NodeID == Int {
     }
 
     /// Initialize a NDTree with a list of points and a key path to the vector.
-    /// - Parameters: 
+    ///
+    /// - Parameters:
     ///  - points: A list of points. The points are only used to calculate the covering box. You should still call `add` to add the points to the tree.
     ///  - keyPath: A key path to the vector in the element of the list.
     ///  - clusterDistance: If 2 points are close enough, they will be clustered into the same leaf node.
@@ -318,10 +329,14 @@ extension Quadtree {
     /// The bounding box of the current node
     @inlinable public var extent: Box { box }
 
-    /// Returns true is the current tree node is leaf. Does not guarantee that the tree node has point in it.
+    /// Returns true is the current tree node is leaf. 
+    ///
+    /// Does not guarantee that the tree node has point in it.
     @inlinable public var isLeaf: Bool { children == nil }
 
-    /// Returns true is the current tree node is internal. Internal tree node are always empty and do not contain any points.
+    /// Returns true is the current tree node is internal. 
+    ///
+    /// Internal tree node are always empty and do not contain any points.
     @inlinable public var isInternalNode: Bool { children != nil }
 
     /// Returns true is the current tree node is leaf and has point in it.

--- a/Sources/ForceSimulation/NDTree/VectorLike.swift
+++ b/Sources/ForceSimulation/NDTree/VectorLike.swift
@@ -8,6 +8,7 @@
 
 
 /// A vector-like type that can be used in a `ForceSimulation`.
+///
 /// The members required by `VectorLike` are basically the same as `simd`'s `SIMD` protocol.
 /// `NDTree` only rely on this protocol so that you can implement your structure on the platforms
 /// that do not support `simd`.
@@ -17,18 +18,22 @@ public protocol VectorLike: CustomStringConvertible, Decodable, Encodable, Expre
     associatedtype Scalar: FloatingPoint, Decodable, Encodable, Hashable, CustomDebugStringConvertible
     
     /// The length of the vector squared.
+    ///
     /// This property should be implemented even if you are using `simd`.
     @inlinable func lengthSquared() -> Scalar
 
     /// The length of the vector.
+    ///
     /// This property should be implemented even if you are using `simd`.
     @inlinable func length() -> Scalar
 
     /// The distance to another vector, squared.
+    ///
     /// This property should be implemented even if you are using `simd`.
     @inlinable func distanceSquared(to: Self) -> Scalar
 
     /// The distance to another vector.
+    /// 
     /// This property should be implemented even if you are using `simd`.
     @inlinable func distance(to: Self) -> Scalar
     

--- a/Sources/ForceSimulation/Simulation2D/Simulation2D.CenterForce.swift
+++ b/Sources/ForceSimulation/Simulation2D/Simulation2D.CenterForce.swift
@@ -12,6 +12,7 @@ import simd
 
 extension Simulation2D {
     /// A force that drives nodes towards the center.
+    ///
     /// Center force is relatively fast, the complexity is `O(n)`,
     /// where `n` is the number of nodes.
     /// See [Collide Force - D3](https://d3js.org/d3-force/collide).
@@ -46,6 +47,7 @@ extension Simulation2D {
     }
 
     /// Create a center force that drives nodes towards the center.
+    /// 
     /// Center force is relatively fast, the complexity is `O(n)`,
     /// where `n` is the number of nodes.
     /// See [Collide Force - D3](https://d3js.org/d3-force/collide).

--- a/Sources/ForceSimulation/Simulation2D/Simulation2D.CollideForce.swift
+++ b/Sources/ForceSimulation/Simulation2D/Simulation2D.CollideForce.swift
@@ -48,6 +48,7 @@ struct MaxRadiusTreeDelegate2D<NodeID>: QuadtreeDelegate where NodeID: Hashable 
 extension Simulation2D {
 
     /// A force that prevents nodes from overlapping.
+    ///
     /// This is a very expensive force, the complexity is `O(n log(n))`,
     /// where `n` is the number of nodes.
     /// See [Collide Force - D3](https://d3js.org/d3-force/collide).
@@ -182,6 +183,7 @@ extension Simulation2D {
     }
 
     /// Create a collide force that prevents nodes from overlapping.
+    /// 
     /// This is a very expensive force, the complexity is `O(n log(n))`,
     /// where `n` is the number of nodes.
     /// See [Collide Force - D3](https://d3js.org/d3-force/collide).

--- a/Sources/ForceSimulation/Simulation2D/Simulation2D.DirectionForce.swift
+++ b/Sources/ForceSimulation/Simulation2D/Simulation2D.DirectionForce.swift
@@ -14,6 +14,7 @@ import simd
 extension Simulation2D {
 
     /// A force that moves nodes to a target position.
+    /// 
     /// Center force is relatively fast, the complexity is `O(n)`,
     /// where `n` is the number of nodes.
     /// See [Position Force - D3](https://d3js.org/d3-force/position).

--- a/Sources/ForceSimulation/Simulation2D/Simulation2D.LinkForce.swift
+++ b/Sources/ForceSimulation/Simulation2D/Simulation2D.LinkForce.swift
@@ -14,6 +14,7 @@ enum LinkForce2DError: Error {
 }
 extension Simulation2D {
     /// A force that represents links between nodes.
+    ///
     /// The complexity is `O(e)`, where `e` is the number of links.
     /// See [Link Force - D3](https://d3js.org/d3-force/link).
     final public class LinkForce: ForceLike
@@ -139,8 +140,9 @@ extension Simulation2D {
 
     }
 
-    /// Create a link force that represents links between nodes. It works like
-    /// there is a spring between each pair of nodes.
+    /// Create a link force that represents links between nodes. 
+    ///
+    /// It works like there is a spring between each pair of nodes.
     /// The complexity is `O(e)`, where `e` is the number of links.
     /// See [Collide Force - D3](https://d3js.org/d3-force/collide)
     /// - Parameters:
@@ -161,8 +163,9 @@ extension Simulation2D {
         return linkForce
     }
 
-    /// Create a link force that represents links between nodes. It works like
-    /// there is a spring between each pair of nodes.
+    /// Create a link force that represents links between nodes.
+    /// 
+    /// It works like there is a spring between each pair of nodes.
     /// The complexity is `O(e)`, where `e` is the number of links.
     /// See [Link Force - D3](https://d3js.org/d3-force/link).
     /// - Parameters:

--- a/Sources/ForceSimulation/Simulation2D/Simulation2D.ManyBodyForce.swift
+++ b/Sources/ForceSimulation/Simulation2D/Simulation2D.ManyBodyForce.swift
@@ -81,6 +81,7 @@ public enum ManyBodyForce2DError: Error {
 extension Simulation2D {
 
     /// A force that simulate the many-body force.
+    ///
     /// This is a very expensive force, the complexity is `O(n log(n))`,
     /// where `n` is the number of nodes. The complexity might degrade to `O(n^2)` if the nodes are too close to each other.
     /// See [Manybody Force - D3](https://d3js.org/d3-force/many-body).
@@ -302,6 +303,7 @@ extension Simulation2D {
     }
 
     /// Create a many-body force that simulate the many-body force.
+    /// 
     /// This is a very expensive force, the complexity is `O(n log(n))`,
     /// where `n` is the number of nodes. The complexity might degrade to `O(n^2)` if the nodes are too close to each other.
     /// The force mimics the gravity force or electrostatic force.

--- a/Sources/ForceSimulation/Simulation2D/Simulation2D.RadialForce.swift
+++ b/Sources/ForceSimulation/Simulation2D/Simulation2D.RadialForce.swift
@@ -11,6 +11,7 @@ import simd
 
 extension Simulation2D {
     /// A force that applies a radial force to all nodes.
+    ///
     /// Center force is relatively fast, the complexity is `O(n)`,
     /// where `n` is the number of nodes.
     /// See [Position Force - D3](https://d3js.org/d3-force/position).
@@ -68,6 +69,7 @@ extension Simulation2D {
     }
 
     /// Create a radial force that applies a radial force to all nodes.
+    /// 
     /// Center force is relatively fast, the complexity is `O(n)`,
     /// where `n` is the number of nodes.
     /// See [Position Force - D3](https://d3js.org/d3-force/position).

--- a/Sources/ForceSimulation/Simulation2D/Simulation2D.swift
+++ b/Sources/ForceSimulation/Simulation2D/Simulation2D.swift
@@ -23,16 +23,19 @@ where NodeID: Hashable {
     public internal(set) var forces: [any ForceLike] = []
 
     /// The position of points stored in simulation.
+    ///
     /// Ordered as the nodeIds you passed in when initializing simulation.
     /// They are always updated.
     public internal(set) var nodePositions: [V]
 
     /// The velocities of points stored in simulation.
+    ///
     /// Ordered as the nodeIds you passed in when initializing simulation.
     /// They are always updated.
     public internal(set) var nodeVelocities: [V]
 
     /// The fixed positions of points stored in simulation.
+    ///
     /// Ordered as the nodeIds you passed in when initializing simulation.
     /// They are always updated.
     public internal(set) var nodeFixations: [V?]
@@ -42,6 +45,7 @@ where NodeID: Hashable {
     @usableFromInline internal private(set) var nodeIdToIndexLookup: [NodeID: Int] = [:]
 
     /// Create a new simulation.
+    /// 
     /// - Parameters:
     ///   - nodeIds: Hashable identifiers for the nodes. Force simulation calculate them by order once created.
     ///   - alpha:
@@ -96,12 +100,15 @@ where NodeID: Hashable {
         return nodeIdToIndexLookup[nodeId]!
     }
 
-    /// Reset the alpha. The points will move faster as alpha gets larger.
+    /// Reset the alpha. 
+    ///
+    /// The points will move faster as alpha gets larger.
     public func resetAlpha(_ alpha: Scalar) {
         self.alpha = alpha
     }
 
     /// Run the simulation for a number of iterations.
+    ///
     /// Goes through all the forces created.
     /// The forces will call  `apply` then the positions and velocities will be modified.
     /// - Parameter iterationCount: Default to 1.

--- a/Sources/ForceSimulation/Simulation3D/Simulation3D.CenterForce.swift
+++ b/Sources/ForceSimulation/Simulation3D/Simulation3D.CenterForce.swift
@@ -13,6 +13,7 @@ import simd
 
 extension Simulation3D {
     /// A force that drives nodes towards the center.
+    ///
     /// Center force is relatively fast, the complexity is `O(n)`,
     /// where `n` is the number of nodes.
     /// See [Collide Force - D3](https://d3js.org/d3-force/collide).
@@ -47,6 +48,7 @@ extension Simulation3D {
     }
 
     /// Create a center force that drives nodes towards the center.
+    /// 
     /// Center force is relatively fast, the complexity is `O(n)`,
     /// where `n` is the number of nodes.
     /// See [Collide Force - D3](https://d3js.org/d3-force/collide).

--- a/Sources/ForceSimulation/Simulation3D/Simulation3D.CollideForce.swift
+++ b/Sources/ForceSimulation/Simulation3D/Simulation3D.CollideForce.swift
@@ -50,6 +50,7 @@ struct MaxRadiusTreeDelegate3D<NodeID>: OctreeDelegate where NodeID: Hashable {
 extension Simulation3D {
 
     /// A force that prevents nodes from overlapping.
+    ///
     /// This is a very expensive force, the complexity is `O(n log(n))`,
     /// where `n` is the number of nodes.
     /// See [Collide Force - D3](https://d3js.org/d3-force/collide).
@@ -184,6 +185,7 @@ extension Simulation3D {
     }
 
     /// Create a collide force that prevents nodes from overlapping.
+    /// 
     /// This is a very expensive force, the complexity is `O(n log(n))`,
     /// where `n` is the number of nodes.
     /// See [Collide Force - D3](https://d3js.org/d3-force/collide).

--- a/Sources/ForceSimulation/Simulation3D/Simulation3D.DirectionForce.swift
+++ b/Sources/ForceSimulation/Simulation3D/Simulation3D.DirectionForce.swift
@@ -14,6 +14,7 @@ import simd
 extension Simulation3D {
 
     /// A force that moves nodes to a target position.
+    ///
     /// Center force is relatively fast, the complexity is `O(n)`,
     /// where `n` is the number of nodes.
     /// See [Position Force - D3](https://d3js.org/d3-force/position).
@@ -74,6 +75,7 @@ extension Simulation3D {
     }
 
     /// Create a direction force that moves nodes to a target position.
+    /// 
     /// Center force is relatively fast, the complexity is `O(n)`,
     /// where `n` is the number of nodes.
     /// See [Position Force - D3](https://d3js.org/d3-force/position).

--- a/Sources/ForceSimulation/Simulation3D/Simulation3D.LinkForce.swift
+++ b/Sources/ForceSimulation/Simulation3D/Simulation3D.LinkForce.swift
@@ -14,6 +14,7 @@ enum LinkForce3DError: Error {
 }
 extension Simulation3D {
     /// A force that represents links between nodes.
+    /// 
     /// The complexity is `O(e)`, where `e` is the number of links.
     /// See [Link Force - D3](https://d3js.org/d3-force/link).
     final public class LinkForce: ForceLike

--- a/Sources/ForceSimulation/Simulation3D/Simulation3D.ManyBodyForce.swift
+++ b/Sources/ForceSimulation/Simulation3D/Simulation3D.ManyBodyForce.swift
@@ -81,6 +81,7 @@ struct MassQuadtreeDelegate3D<NodeID>: OctreeDelegate where NodeID: Hashable {
 extension Simulation3D {
 
     /// A force that simulate the many-body force.
+    ///
     /// This is a very expensive force, the complexity is `O(n log(n))`,
     /// where `n` is the number of nodes. The complexity might degrade to `O(n^2)` if the nodes are too close to each other.
     /// See [Manybody Force - D3](https://d3js.org/d3-force/many-body).
@@ -302,6 +303,7 @@ extension Simulation3D {
     }
 
     /// Create a many-body force that simulate the many-body force.
+    /// 
     /// This is a very expensive force, the complexity is `O(n log(n))`,
     /// where `n` is the number of nodes. The complexity might degrade to `O(n^2)` if the nodes are too close to each other.
     /// The force mimics the gravity force or electrostatic force.

--- a/Sources/ForceSimulation/Simulation3D/Simulation3D.RadialForce.swift
+++ b/Sources/ForceSimulation/Simulation3D/Simulation3D.RadialForce.swift
@@ -11,6 +11,7 @@ import simd
 
 extension Simulation3D {
     /// A force that applies a radial force to all nodes.
+    ///
     /// Center force is relatively fast, the complexity is `O(n)`,
     /// where `n` is the number of nodes.
     /// See [Position Force - D3](https://d3js.org/d3-force/position).
@@ -67,6 +68,7 @@ extension Simulation3D {
     }
 
     /// Create a radial force that applies a radial force to all nodes.
+    /// 
     /// Center force is relatively fast, the complexity is `O(n)`,
     /// where `n` is the number of nodes.
     /// See [Position Force - D3](https://d3js.org/d3-force/position).

--- a/Sources/ForceSimulation/Simulation3D/Simulation3D.swift
+++ b/Sources/ForceSimulation/Simulation3D/Simulation3D.swift
@@ -36,16 +36,19 @@ where NodeID: Hashable{
     public internal(set) var forces: [any ForceLike] = []
 
     /// The position of points stored in simulation.
+    ///
     /// Ordered as the nodeIds you passed in when initializing simulation.
     /// They are always updated.
     public internal(set) var nodePositions: [V]
 
     /// The velocities of points stored in simulation.
+    ///
     /// Ordered as the nodeIds you passed in when initializing simulation.
     /// They are always updated.
     public internal(set) var nodeVelocities: [V]
 
     /// The fixed positions of points stored in simulation.
+    ///
     /// Ordered as the nodeIds you passed in when initializing simulation.
     /// They are always updated.
     public internal(set) var nodeFixations: [V?]
@@ -55,6 +58,7 @@ where NodeID: Hashable{
     @usableFromInline internal private(set) var nodeIdToIndexLookup: [NodeID: Int] = [:]
 
     /// Create a new simulation.
+    /// 
     /// - Parameters:
     ///   - nodeIds: Hashable identifiers for the nodes. Force simulation calculate them by order once created.
     ///   - alpha:
@@ -104,17 +108,21 @@ where NodeID: Hashable{
     }
 
     /// Get the index in the nodeArray for `nodeId`
+    ///
     /// - **Complexity**: O(1)
     public func getIndex(of nodeId: NodeID) -> Int {
         return nodeIdToIndexLookup[nodeId]!
     }
 
-    /// Reset the alpha. The points will move faster as alpha gets larger.
+    /// Reset the alpha. 
+    ///
+    /// The points will move faster as alpha gets larger.
     public func resetAlpha(_ alpha: Scalar) {
         self.alpha = alpha
     }
 
     /// Run the simulation for a number of iterations.
+    ///
     /// Goes through all the forces created.
     /// The forces will call  `apply` then the positions and velocities will be modified.
     /// - Parameter iterationCount: Default to 1.

--- a/Sources/ForceSimulation/SimulationKD/SimulationKD.CenterForce.swift
+++ b/Sources/ForceSimulation/SimulationKD/SimulationKD.CenterForce.swift
@@ -8,6 +8,7 @@
 
 extension SimulationKD {
     /// A force that drives nodes towards the center.
+    /// 
     /// Center force is relatively fast, the complexity is `O(n)`,
     /// where `n` is the number of nodes.
     /// See [Collide Force - D3](https://d3js.org/d3-force/collide).
@@ -41,6 +42,7 @@ extension SimulationKD {
     }
 
     /// Create a center force that drives nodes towards the center.
+    /// 
     /// Center force is relatively fast, the complexity is `O(n)`,
     /// where `n` is the number of nodes.
     /// See [Collide Force - D3](https://d3js.org/d3-force/collide).

--- a/Sources/ForceSimulation/SimulationKD/SimulationKD.CollideForce.swift
+++ b/Sources/ForceSimulation/SimulationKD/SimulationKD.CollideForce.swift
@@ -42,6 +42,7 @@ struct MaxRadiusTreeDelegate<NodeID, V>: NDTreeDelegate where NodeID: Hashable, 
 
 extension SimulationKD {
     /// A force that prevents nodes from overlapping.
+    ///
     /// This is a very expensive force, the complexity is `O(n log(n))`,
     /// where `n` is the number of nodes.
     /// See [Collide Force - D3](https://d3js.org/d3-force/collide).
@@ -174,6 +175,7 @@ extension SimulationKD {
     }
 
     /// Create a collide force that prevents nodes from overlapping.
+    /// 
     /// This is a very expensive force, the complexity is `O(n log(n))`,
     /// where `n` is the number of nodes.
     /// See [Collide Force - D3](https://d3js.org/d3-force/collide).

--- a/Sources/ForceSimulation/SimulationKD/SimulationKD.DirectionForce.swift
+++ b/Sources/ForceSimulation/SimulationKD/SimulationKD.DirectionForce.swift
@@ -9,6 +9,7 @@
 
 extension SimulationKD {
     /// A force that moves nodes to a target position.
+    ///
     /// Center force is relatively fast, the complexity is `O(n)`,
     /// where `n` is the number of nodes.
     /// See [Position Force - D3](https://d3js.org/d3-force/position).
@@ -67,6 +68,7 @@ extension SimulationKD {
     }
 
     /// Create a direction force that moves nodes to a target position.
+    /// 
     /// Center force is relatively fast, the complexity is `O(n)`,
     /// where `n` is the number of nodes.
     /// See [Position Force - D3](https://d3js.org/d3-force/position).

--- a/Sources/ForceSimulation/SimulationKD/SimulationKD.LinkForce.swift
+++ b/Sources/ForceSimulation/SimulationKD/SimulationKD.LinkForce.swift
@@ -13,6 +13,7 @@ enum LinkForceError: Error {
 
 extension SimulationKD {
     /// A force that represents links between nodes.
+    /// 
     /// The complexity is `O(e)`, where `e` is the number of links.
     /// See [Link Force - D3](https://d3js.org/d3-force/link).
     final public class LinkForce: ForceLike

--- a/Sources/ForceSimulation/SimulationKD/SimulationKD.ManyBodyForce.swift
+++ b/Sources/ForceSimulation/SimulationKD/SimulationKD.ManyBodyForce.swift
@@ -76,6 +76,7 @@ struct MassQuadtreeDelegate<NodeID, V>: NDTreeDelegate where NodeID: Hashable, V
 
 extension SimulationKD {
     /// A force that simulate the many-body force.
+    ///
     /// This is a very expensive force, the complexity is `O(n log(n))`,
     /// where `n` is the number of nodes. The complexity might degrade to `O(n^2)` if the nodes are too close to each other.
     /// See [Manybody Force - D3](https://d3js.org/d3-force/many-body).
@@ -299,6 +300,7 @@ extension SimulationKD {
     }
 
     /// Create a many-body force that simulate the many-body force.
+    /// 
     /// This is a very expensive force, the complexity is `O(n log(n))`,
     /// where `n` is the number of nodes. The complexity might degrade to `O(n^2)` if the nodes are too close to each other.
     /// The force mimics the gravity force or electrostatic force.

--- a/Sources/ForceSimulation/SimulationKD/SimulationKD.RadialForce.swift
+++ b/Sources/ForceSimulation/SimulationKD/SimulationKD.RadialForce.swift
@@ -11,6 +11,7 @@
 extension SimulationKD {
 
 /// A force that applies a radial force to all nodes.
+    /// 
 /// Center force is relatively fast, the complexity is `O(n)`,
 /// where `n` is the number of nodes.
 /// See [Position Force - D3](https://d3js.org/d3-force/position).

--- a/Sources/ForceSimulation/SimulationKD/SimulationKD.swift
+++ b/Sources/ForceSimulation/SimulationKD/SimulationKD.swift
@@ -51,6 +51,7 @@ where NodeID: Hashable, V: VectorLike, V.Scalar : SimulatableFloatingPoint {
     @usableFromInline internal private(set) var nodeIdToIndexLookup: [NodeID: Int] = [:]
 
     /// Create a new simulation.
+    /// 
     /// - Parameters:
     ///   - nodeIds: Hashable identifiers for the nodes. Force simulation calculate them by order once created.
     ///   - alpha:
@@ -111,6 +112,7 @@ where NodeID: Hashable, V: VectorLike, V.Scalar : SimulatableFloatingPoint {
     }
 
     /// Run the simulation for a number of iterations.
+    /// 
     /// Goes through all the forces created.
     /// The forces will call  `apply` then the positions and velocities will be modified.
     /// - Parameter iterationCount: Default to 1.

--- a/Sources/ForceSimulation/Utils.swift
+++ b/Sources/ForceSimulation/Utils.swift
@@ -108,8 +108,9 @@ extension VectorLike where Scalar: SimulatableFloatingPoint {
 }
 
 
-/// A Hashable identifier for an edge. It’s a utility type for preserving the
-/// `Hashable` conformance.
+/// A Hashable identifier for an edge. 
+///
+/// It’s a utility type for preserving `Hashable` conformance.
 public struct EdgeID<NodeID>: Hashable where NodeID: Hashable {
     public let source: NodeID
     public let target: NodeID


### PR DESCRIPTION
- breaks up the abstracts from the discussion sections to make the top-level stuff more concise, while preserving the detail within the various symbols
- adds a top-level pass of organization ("curation") to provide more concise organization the documentation