### PR TITLE
Add GraphProxy and .graphOverlay(alignment:content:)

### DIFF
--- a/Examples/ForceDirectedGraphExample/ForceDirectedGraphExample/MermaidVisualization.swift
+++ b/Examples/ForceDirectedGraphExample/ForceDirectedGraphExample/MermaidVisualization.swift
@@ -99,9 +99,16 @@ struct MermaidVisualization: View {
         } emittingNewNodesWithStates: { id in
             KineticState(position: getInitialPosition(id: id, r: 100))
         }
-        .onNodeTapped {
-            tappedNode = $0
-        }
+        .graphOverlay(content: { proxy in
+            Rectangle().fill(.clear).contentShape(Rectangle())
+                .onTapGesture { value in
+                    if let nodeID = proxy.locateNode(at: .init(x: value.x, y: value.y)) {
+                        guard let nodeID = nodeID as? String else { return }
+                        print(nodeID)
+                        tappedNode = nodeID
+                    }
+                }
+        })
         .ignoresSafeArea()
         #if !os(visionOS)
         .inspector(isPresented: .constant(true)) {

--- a/Sources/Grape/Contents/AnyGraphContent.swift
+++ b/Sources/Grape/Contents/AnyGraphContent.swift
@@ -1,16 +1,16 @@
-@usableFromInline
-struct AnyGraphContent<NodeID: Hashable>: GraphContent {
+
+public struct AnyGraphContent<NodeID: Hashable>: GraphContent {
 
     @usableFromInline
     let storage: any GraphContent<NodeID>
 
     @inlinable
-    init(_ storage: any GraphContent<NodeID>) {
+    public init(_ storage: any GraphContent<NodeID>) {
         self.storage = storage
     }
 
     @inlinable
-    func _attachToGraphRenderingContext(_ context: inout _GraphRenderingContext<NodeID>) {
+    public func _attachToGraphRenderingContext(_ context: inout _GraphRenderingContext<NodeID>) {
         storage._attachToGraphRenderingContext(&context)
     }
 

--- a/Sources/Grape/Contents/GraphContent.swift
+++ b/Sources/Grape/Contents/GraphContent.swift
@@ -7,5 +7,3 @@ public protocol GraphContent<NodeID> {
     @inlinable
     func _attachToGraphRenderingContext(_ context: inout _GraphRenderingContext<NodeID>)
 }
-
-

--- a/Sources/Grape/Modifiers/GraphProxy.swift
+++ b/Sources/Grape/Modifiers/GraphProxy.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+public struct GraphProxy {
+    
+    @usableFromInline
+    let storage: (any _AnyGraphProxyProtocol)?
+    
+    @inlinable
+    init(_ storage: some _AnyGraphProxyProtocol) {
+        self.storage = storage
+    }
+
+    @inlinable
+    public init() {
+        self.storage = nil
+    }
+}
+
+extension GraphProxy: _AnyGraphProxyProtocol {
+    public func locateNode(at locationInViewportCoordinate: CGPoint) -> AnyHashable? {
+        storage?.locateNode(at: locationInViewportCoordinate)   
+    }
+}
+
+@usableFromInline
+struct GraphProxyKey: PreferenceKey {
+    @inlinable
+    static func reduce(value: inout GraphProxy, nextValue: () -> GraphProxy) {
+        value = nextValue()
+    }
+    
+    @inlinable
+    static var defaultValue: GraphProxy {
+        get {
+            .init()
+        }
+    }
+}
+
+
+
+extension View {
+    @inlinable
+    public func graphOverlay<V>(
+        alignment: Alignment = .center,
+        @ViewBuilder content: @escaping (GraphProxy) -> V
+    ) -> some View where V: View {
+        self.overlayPreferenceValue(GraphProxyKey.self, content)
+    }
+}

--- a/Sources/Grape/Views/ForceDirectedGraph+Gesture.swift
+++ b/Sources/Grape/Views/ForceDirectedGraph+Gesture.swift
@@ -79,17 +79,17 @@ import SwiftUI
         @inlinable
         static var minimumDragDistance: CGFloat { 3.0 }
     }
-    @MainActor
-    extension ForceDirectedGraph {
-        @inlinable
-        internal func onTapGesture(
-            _ location: CGPoint
-        ) {
-            guard let action = self.model._onNodeTapped else { return }
-            let nodeID = self.model.findNode(at: location)
-            action(nodeID)
-        }
-    }
+    // @MainActor
+    // extension ForceDirectedGraph {
+    //     @inlinable
+    //     internal func onTapGesture(
+    //         _ location: CGPoint
+    //     ) {
+    //         guard let action = self.model._onNodeTapped else { return }
+    //         let nodeID = self.model.findNode(at: location)
+    //         action(nodeID)
+    //     }
+    // }
 #endif
 
 #if os(iOS) || os(macOS)
@@ -192,14 +192,23 @@ extension ForceDirectedGraph {
     }
 
     @inlinable
+    @available(*, deprecated, message: "Use `graphOverlay` instead")
     public func onNodeTapped(
         perform action: @escaping (NodeID?) -> Void
-    ) -> Self {
-        self.model._onNodeTapped = action
-        return self
+    ) -> some View {
+        self.graphOverlay { proxy in
+            Rectangle().fill(.clear).contentShape(Rectangle())
+                .onTapGesture { value in
+                    if let nodeID = proxy.locateNode(at: .init(x: value.x, y: value.y)) {
+                        guard let nodeID = nodeID as? NodeID else { return }
+                        action(nodeID)
+                    }
+                }
+        }
     }
 
     @inlinable
+    @available(*, deprecated, message: "Use `graphOverlay` instead")
     public func onNodeDragChanged(
         perform action: @escaping (NodeID, CGPoint) -> Void
     ) -> Self {
@@ -208,6 +217,7 @@ extension ForceDirectedGraph {
     }
 
     @inlinable
+    @available(*, deprecated, message: "Use `graphOverlay` instead")
     public func onNodeDragEnded(
         shouldBeFixed action: @escaping (NodeID, CGPoint) -> Bool
     ) -> Self {
@@ -216,6 +226,7 @@ extension ForceDirectedGraph {
     }
 
     @inlinable
+    @available(*, deprecated, message: "Use `graphOverlay` instead")
     public func onGraphMagnified(
         perform action: @escaping () -> Void
     ) -> Self {

--- a/Sources/Grape/Views/ForceDirectedGraph+View.swift
+++ b/Sources/Grape/Views/ForceDirectedGraph+View.swift
@@ -13,6 +13,7 @@ extension ForceDirectedGraph: View {
         //     canvas
         // }
         canvas
+            .preference(key: GraphProxyKey.self, value: .init(model))
             .onChange(
                 of: self._graphRenderingContextShadow,
                 initial: false  // Don't trigger on initial value, keep `changeMessage` as "N/A"
@@ -77,7 +78,7 @@ extension ForceDirectedGraph: View {
             .onChanged(onDragChange)
             .onEnded(onDragEnd)
         )
-        .onTapGesture(count: 1, perform: onTapGesture)
+        // .onTapGesture(count: 1, perform: onTapGesture)
 #endif
 
 #if os(iOS) || os(macOS)

--- a/Sources/Grape/Views/ForceDirectedGraph.swift
+++ b/Sources/Grape/Views/ForceDirectedGraph.swift
@@ -37,7 +37,7 @@ where NodeID == Content.NodeID {
 
     // @State
     @inlinable
-    internal var model: ForceDirectedGraphModel<Content>
+    internal var model: ForceDirectedGraphModel<Content.NodeID>
     {
         @storageRestrictions(initializes: _model)
         init(initialValue) {
@@ -48,7 +48,7 @@ where NodeID == Content.NodeID {
     }
 
     @usableFromInline
-    internal var _model: State<ForceDirectedGraphModel<Content>>
+    internal var _model: State<ForceDirectedGraphModel<Content.NodeID>>
 
     /// The default force to be applied to the graph
     ///

--- a/Sources/Grape/Views/ForceDirectedGraphModel.swift
+++ b/Sources/Grape/Views/ForceDirectedGraphModel.swift
@@ -3,8 +3,24 @@ import Foundation
 import Observation
 import SwiftUI
 
+
 @MainActor
-public final class ForceDirectedGraphModel<Content: GraphContent> {
+public protocol _AnyGraphProxyProtocol {
+    @inlinable
+    func locateNode(at locationInViewportCoordinate: CGPoint) -> AnyHashable?
+}
+
+extension ForceDirectedGraphModel: _AnyGraphProxyProtocol {
+    public func locateNode(at locationInViewportCoordinate: CGPoint) -> AnyHashable? {
+        if let nodeID = findNode(at: locationInViewportCoordinate) {
+            return AnyHashable(nodeID)
+        } else {
+            return nil
+        }
+    }
+}
+@MainActor
+public final class ForceDirectedGraphModel<NodeID: Hashable> {
 
     @usableFromInline
     internal struct ObsoleteState {
@@ -12,7 +28,7 @@ public final class ForceDirectedGraphModel<Content: GraphContent> {
         var cgSize: CGSize
     }
 
-    public typealias NodeID = Content.NodeID
+    // public typealias NodeID = Content.NodeID
 
     @usableFromInline
     var graphRenderingContext: _GraphRenderingContext<NodeID>
@@ -128,8 +144,8 @@ public final class ForceDirectedGraphModel<Content: GraphContent> {
     @usableFromInline
     var _onNodeDragEnded: ((NodeID, CGPoint) -> Bool)? = nil
 
-    @usableFromInline
-    var _onNodeTapped: ((NodeID?) -> Void)? = nil
+    // @usableFromInline
+    // var _onNodeTapped: ((NodeID?) -> Void)? = nil
 
     @usableFromInline
     var _onViewportTransformChanged: ((ViewportTransform, Bool) -> Void)? = nil

--- a/Sources/Grape/Views/RenderOperation.swift
+++ b/Sources/Grape/Views/RenderOperation.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 @usableFromInline
-enum PathOrSymbolSize {
+enum PathOrSymbolSize: Equatable {
     case path(Path)
     case symbolSize(CGSize)
 }
@@ -60,7 +60,7 @@ extension RenderOperation.Node: Equatable {
     @inlinable
     internal static func == (lhs: Self, rhs: Self) -> Bool {
         let fillEq = lhs.fill == nil && rhs.fill == nil
-        let pathEq = lhs.pathOrSymbolSize == nil && rhs.pathOrSymbolSize == nil
+        let pathEq = lhs.pathOrSymbolSize == rhs.pathOrSymbolSize
         return lhs.mark == rhs.mark
             && fillEq
             && lhs.stroke == rhs.stroke

--- a/Tests/GrapeTests/ContentBuilderTests.swift
+++ b/Tests/GrapeTests/ContentBuilderTests.swift
@@ -29,9 +29,9 @@ final class ContentBuilderTests: XCTestCase {
             
             NodeMark(id: 3)
             NodeMark(id: 4)
-            AnyGraphContent(
-                NodeMark(id: 5)
-            )
+            // AnyGraphContent(
+            //     NodeMark(id: 5)
+            // )
         }
     }
 


### PR DESCRIPTION
This PR deprecates old gesture modifiers and introduces new `.graphOverlay(alignment:content:)` that aligns with the Swift Charts API and addresses #60 and partially #61 